### PR TITLE
Bug fix for z0t 

### DIFF
--- a/drivers/ccpp/noahmpdrv.F90
+++ b/drivers/ccpp/noahmpdrv.F90
@@ -128,8 +128,6 @@
 !!    - Call penman() to calculate potential evaporation.
 !!    - Calculate the surface specific humidity and convert surface sensible and latent heat fluxes in W m-2 from their kinematic values.
 !!    - If a "guess" run, restore the land-related prognostic fields.
-!                                                                       !
-!-----------------------------------
   subroutine noahmpdrv_run                                       &
 !...................................
 !  ---  inputs:
@@ -163,7 +161,7 @@
       sncovr1, qsurf, gflux, drain, evap, hflx, ep, runoff,      &
       cmm, chh, evbs, evcw, sbsno, pah, ecan, etran, edir, snowc,&
       stm, snohf,smcwlt2, smcref2, wet1, t2mmp, q2mp,zvfun,      &
-      errmsg, errflg)     
+      ztmax, errmsg, errflg)     
 
   use machine ,   only : kind_phys
   use funcphys,   only : fpvs
@@ -362,6 +360,7 @@
   real(kind=kind_phys), dimension(:)     , intent(out)   :: t2mmp      ! combined T2m from tiles
   real(kind=kind_phys), dimension(:)     , intent(out)   :: q2mp       ! combined q2m from tiles
   real(kind=kind_phys), dimension(:)     , intent(out)   :: zvfun      ! 
+  real(kind=kind_phys), dimension(:)     , intent(out)   :: ztmax      ! thermal roughness length
   character(len=*)    ,                    intent(out)   :: errmsg
   integer             ,                    intent(out)   :: errflg
 
@@ -958,6 +957,7 @@ do i = 1, im
       cmxy      (i)   = cm_noahmp
       chxy      (i)   = ch_noahmp
       zorl      (i)   = z0_total * 100.0  ! convert to cm
+      ztmax     (i)   = z0h_total 
 
       smc       (i,:) = soil_moisture_vol
       slc       (i,:) = soil_liquid_vol

--- a/drivers/ccpp/noahmpdrv.meta
+++ b/drivers/ccpp/noahmpdrv.meta
@@ -1315,6 +1315,14 @@
   type = real
   kind = kind_phys
   intent = out
+[ztmax]
+  standard_name = bounded_surface_roughness_length_for_heat_over_land
+  long_name = bounded surface roughness length for heat over land
+  units = m
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/drivers/nuopc/lnd_comp_driver.F90
+++ b/drivers/nuopc/lnd_comp_driver.F90
@@ -612,7 +612,8 @@ contains
          noahmp%model%snowc    , noahmp%model%stm       , &
          noahmp%model%snohf    , noahmp%model%smcwlt2   , noahmp%model%smcref2   , &
          noahmp%model%wet1     , noahmp%model%t2mmp     , noahmp%model%q2mp      , &
-         noahmp%model%zvfun    , noahmp%static%errmsg   , noahmp%static%errflg)
+         noahmp%model%zvfun    , noahmp%model%ztmax     , &
+         noahmp%static%errmsg   , noahmp%static%errflg)
 
     !----------------------
     ! unit conversions

--- a/drivers/nuopc/lnd_comp_io.F90
+++ b/drivers/nuopc/lnd_comp_io.F90
@@ -2243,6 +2243,7 @@ contains
     call fld_add("rho"       ,"density"                                                           ,"kg/m3"  ,ptr2d=ptr2d, v1r8=noahmp%model%rho)
     call fld_add("hgt"       ,"forcing height"                                                    ,"m"      ,ptr2d=ptr2d, v1r8=noahmp%forc%hgt)
     call fld_add("pblh"      ,"height of pbl"                                                     ,"m"      ,ptr2d=ptr2d, v1r8=noahmp%model%pblh)
+    call fld_add("ztmax"     ,"surface roughness length for heat over land"                       ,"m"      ,ptr2d=ptr2d, v1r8=noahmp%model%ztmax)
 
     !----------------------
     ! masked out data over ocean/inland water/lake

--- a/drivers/nuopc/lnd_comp_types.F90
+++ b/drivers/nuopc/lnd_comp_types.F90
@@ -197,6 +197,7 @@ module lnd_comp_types
      real(kind=kp), allocatable :: t2mmp      (:)   ! combined T2m from tiles
      real(kind=kp), allocatable :: q2mp       (:)   ! combined q2m from tiles
      real(kind=kp), allocatable :: zvfun      (:)   ! some function of vegetation used for gfs stability
+     real(kind=kp), allocatable :: ztmax      (:)   ! bounded surface roughness length for heat over land
      real(kind=kp), allocatable :: rho        (:)   ! air density
      real(kind=kp), allocatable :: pores      (:)   ! max soil moisture for a given soil type for land surface model
      real(kind=kp), allocatable :: resid      (:)   ! min soil moisture for a given soil type for land surface model
@@ -475,6 +476,7 @@ contains
     allocate(this%model%t2mmp      (begl:endl))
     allocate(this%model%q2mp       (begl:endl))
     allocate(this%model%zvfun      (begl:endl))
+    allocate(this%model%ztmax      (begl:endl))
     allocate(this%model%rho        (begl:endl))
     allocate(this%model%pores      (30))
     allocate(this%model%resid      (30))
@@ -640,6 +642,7 @@ contains
     this%model%t2mmp       = 0.0_kp
     this%model%q2mp        = 0.0_kp
     this%model%zvfun       = 0.0_kp
+    this%model%ztmax       = 0.0_kp
     this%model%rho         = 0.0_kp
     this%model%pores       = 0.0_kp
     this%model%resid       = 0.0_kp

--- a/src/module_sf_noahmplsm.f90
+++ b/src/module_sf_noahmplsm.f90
@@ -5430,7 +5430,7 @@ endif   ! croptype == 0
         z0ht = z0mt
      elseif (opt_trs == 2) then
         z0mt  = fveg * z0m      + (1.0 - fveg) * z0mg
-        czil1=10.0 ** (- (0.40/0.07) * parameters%hvt)
+        czil1=10.0 ** (- (0.4) * parameters%hvt)
         z0ht = fveg * z0m*exp(-czil1*0.4*258.2*sqrt(ustarx*z0m))  &
             +(1.0 - fveg) * z0mg*exp(-czil1*0.4*258.2*sqrt(ustarx*z0mg))
      elseif (opt_trs == 3) then
@@ -5466,7 +5466,7 @@ endif   ! croptype == 0
      if (opt_trs == 1) then
         z0ht = z0mt
      elseif (opt_trs == 2) then
-        czil1=10.0 ** (- (0.40/0.07) * parameters%hvt)
+        czil1=10.0 ** (- (0.4) * parameters%hvt)
         z0ht =z0mt*exp(-czil1*0.4*258.2*sqrt(ustarx*z0mt))
      elseif (opt_trs == 3) then
       if (vegtyp.le.5) then
@@ -5492,7 +5492,7 @@ endif   ! croptype == 0
        if (opt_trs == 1) then
          z0ht    = z0mt
        elseif (opt_trs == 2) then
-         czil1= 10.0 ** (- (0.40/0.07) * parameters%hvt)
+         czil1= 10.0 ** (- (0.4) * parameters%hvt)
          z0ht = z0mt*exp(-czil1*0.4*258.2*sqrt(ustarx*z0mt))
        elseif (opt_trs == 3) then
          if (vegtyp.le.5) then


### PR DESCRIPTION
This is a corresponding PR to ccpp-physics PR[#23](https://github.com/ufs-community/ccpp-physics/pull/23). It fixed a bug related to the definition of z0t. A new variable ztmax is added. 