### PR TITLE
FV3 -> UFSATM name change.

### DIFF
--- a/drivers/ccpp/update.sh
+++ b/drivers/ccpp/update.sh
@@ -1,39 +1,39 @@
 #!/bin/bash
 
 echo "checksum - before"
-md5sum ../../../../FV3/ccpp/physics/physics/tools/funcphys.f90 funcphys.f90
-md5sum ../../../../FV3/ccpp/physics/physics/hooks/machine.F machine.F
-md5sum ../../../../FV3/ccpp/physics/physics/hooks/physcons.F90 physcons.F90
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noah/namelist_soilveg.f namelist_soilveg.f
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noah/set_soilveg.f set_soilveg.f
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Layer/UFS/sfc_diff.f sfc_diff.f
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmp_tables.f90 noahmp_tables.f90
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90 noahmpdrv.F90
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmpdrv.meta noahmpdrv.meta
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90 ../../src/module_sf_noahmp_glacier.F90
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90 ../../src/module_sf_noahmplsm.F90
+md5sum ../../../../UFSATM/ccpp/physics/physics/tools/funcphys.f90 funcphys.f90
+md5sum ../../../../UFSATM/ccpp/physics/physics/hooks/machine.F machine.F
+md5sum ../../../../UFSATM/ccpp/physics/physics/hooks/physcons.F90 physcons.F90
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noah/namelist_soilveg.f namelist_soilveg.f
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noah/set_soilveg.f set_soilveg.f
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Layer/UFS/sfc_diff.f sfc_diff.f
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmp_tables.f90 noahmp_tables.f90
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90 noahmpdrv.F90
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmpdrv.meta noahmpdrv.meta
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90 ../../src/module_sf_noahmp_glacier.F90
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90 ../../src/module_sf_noahmplsm.F90
 
-cp -f ../../../../FV3/ccpp/physics/physics/tools/funcphys.f90 .
-cp -f ../../../../FV3/ccpp/physics/physics/hooks/machine.F .
-cp -f ../../../../FV3/ccpp/physics/physics/hooks/physcons.F90 .
-cp -f ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noah/namelist_soilveg.f .
-cp -f ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noah/set_soilveg.f .
-cp -f ../../../../FV3/ccpp/physics/physics/SFC_Layer/UFS/sfc_diff.f .
-cp -f ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmp_tables.f90 .
-cp -f ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90 .
-cp -f ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmpdrv.meta . 
-cp -f ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90 ../../src/.
-cp -f ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90 ../../src/.
+cp -f ../../../../UFSATM/ccpp/physics/physics/tools/funcphys.f90 .
+cp -f ../../../../UFSATM/ccpp/physics/physics/hooks/machine.F .
+cp -f ../../../../UFSATM/ccpp/physics/physics/hooks/physcons.F90 .
+cp -f ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noah/namelist_soilveg.f .
+cp -f ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noah/set_soilveg.f .
+cp -f ../../../../UFSATM/ccpp/physics/physics/SFC_Layer/UFS/sfc_diff.f .
+cp -f ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmp_tables.f90 .
+cp -f ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90 .
+cp -f ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmpdrv.meta . 
+cp -f ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90 ../../src/.
+cp -f ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90 ../../src/.
 
 echo "checksum - after"
-md5sum ../../../../FV3/ccpp/physics/physics/tools/funcphys.f90 funcphys.f90
-md5sum ../../../../FV3/ccpp/physics/physics/hooks/machine.F machine.F
-md5sum ../../../../FV3/ccpp/physics/physics/hooks/physcons.F90 physcons.F90
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noah/namelist_soilveg.f namelist_soilveg.f
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noah/set_soilveg.f set_soilveg.f
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Layer/UFS/sfc_diff.f sfc_diff.f
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmp_tables.f90 noahmp_tables.f90
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90 noahmpdrv.F90
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmpdrv.meta noahmpdrv.meta
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90 ../../src/module_sf_noahmp_glacier.F90
-md5sum ../../../../FV3/ccpp/physics/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90 ../../src/module_sf_noahmplsm.F90
+md5sum ../../../../UFSATM/ccpp/physics/physics/tools/funcphys.f90 funcphys.f90
+md5sum ../../../../UFSATM/ccpp/physics/physics/hooks/machine.F machine.F
+md5sum ../../../../UFSATM/ccpp/physics/physics/hooks/physcons.F90 physcons.F90
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noah/namelist_soilveg.f namelist_soilveg.f
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noah/set_soilveg.f set_soilveg.f
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Layer/UFS/sfc_diff.f sfc_diff.f
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmp_tables.f90 noahmp_tables.f90
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90 noahmpdrv.F90
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/noahmpdrv.meta noahmpdrv.meta
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90 ../../src/module_sf_noahmp_glacier.F90
+md5sum ../../../../UFSATM/ccpp/physics/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90 ../../src/module_sf_noahmplsm.F90


### PR DESCRIPTION
This PR updates the noahmp submodule in the UFS to reflect a recent name change in the atmospheric component of the UFS, from FV3 -> UFSATM.
