### PR TITLE
Removal of goto statements

### DIFF
--- a/drivers/ccpp/noahmpdrv.F90
+++ b/drivers/ccpp/noahmpdrv.F90
@@ -365,8 +365,8 @@ subroutine noahmpdrv_timestep_init (itime, fhour, delt, km,  ncols,         &
 
     deallocate(stc_updated, slc_updated)
     deallocate(mask_tile)
-  
-    write(*,'(a,i4,a,i8)') 'noahmpdrv_timestep_init rank ', Land_IAU_Control%me, ' # of cells with stc update ', nstcupd
+    ! Remove non-warning/error log write
+    !write(*,'(a,i4,a,i8)') 'noahmpdrv_timestep_init rank ', Land_IAU_Control%me, ' # of cells with stc update ', nstcupd
 
 
 end subroutine noahmpdrv_timestep_init

--- a/src/module_sf_noahmplsm.F90
+++ b/src/module_sf_noahmplsm.F90
@@ -6856,7 +6856,7 @@ zolmax = xkrefsqr / sqrt(xkzo)   ! maximum z/L
 !! temperature is below 273.15k (tfrz). requires newton-type iteration
 !! to solve the nonlinear implicit equation given in eqn 17 of koren et al.
 !! (1999, jgr, vol 104(d16),19569-19585)
-subroutine frh2o (parameters,isoil,free,tkelv,smc,sh2o,&
+  subroutine frh2o (parameters,isoil,free,tkelv,smc,sh2o,&
 #ifdef CCPP
      errmsg,errflg)
 #else
@@ -6891,7 +6891,7 @@ subroutine frh2o (parameters,isoil,free,tkelv,smc,sh2o,&
 !   free..........supercooled liquid water content [m3/m3]
 ! ----------------------------------------------------------------------
     implicit none
-  type (noahmp_parameters), intent(in) :: parameters
+    type (noahmp_parameters), intent(in) :: parameters
     integer,intent(in)   :: isoil
     real (kind=kind_phys), intent(in)     :: sh2o,smc,tkelv
     real (kind=kind_phys), intent(out)    :: free
@@ -6943,7 +6943,6 @@ subroutine frh2o (parameters,isoil,free,tkelv,smc,sh2o,&
 ! ----------------------------------------------------------------------
           if (swl < 0.) swl = 0.
           
-          ! Use do while loop instead of goto statements
           do while ((nlog < 10) .and. (kcount == 0))
              nlog = nlog + 1
              df = log ( ( parameters%psisat(isoil) * grav / hfus ) * ( ( 1. + ck * swl )**2.) * &

--- a/src/module_sf_noahmplsm.F90
+++ b/src/module_sf_noahmplsm.F90
@@ -3003,7 +3003,7 @@ endif   ! croptype == 0
     if (ib.eq.1) fsun = 0.
   end do
 
-  if(cosz > 0)
+  if(cosz > 0) then
   ! weight reflectance/transmittance by lai and sai
 
     do ib = 1, nband
@@ -6856,7 +6856,7 @@ zolmax = xkrefsqr / sqrt(xkzo)   ! maximum z/L
 !! temperature is below 273.15k (tfrz). requires newton-type iteration
 !! to solve the nonlinear implicit equation given in eqn 17 of koren et al.
 !! (1999, jgr, vol 104(d16),19569-19585)
-  subroutine frh2o (parameters,isoil,free,tkelv,smc,sh2o,&
+subroutine frh2o (parameters,isoil,free,tkelv,smc,sh2o,&
 #ifdef CCPP
      errmsg,errflg)
 #else
@@ -6900,7 +6900,7 @@ zolmax = xkrefsqr / sqrt(xkzo)   ! maximum z/L
     integer, intent(inout)           :: errflg
 #endif
     real (kind=kind_phys)                 :: bx,denom,df,dswl,fk,swl,swlk
-    integer              :: nlog
+    integer              :: nlog,kcount
 !      parameter(ck = 0.0)
     real (kind=kind_phys), parameter      :: ck = 8.0, blim = 5.5, error = 0.005,       &
          dice = 920.0
@@ -6915,7 +6915,10 @@ zolmax = xkrefsqr / sqrt(xkzo)   ! maximum z/L
 ! ----------------------------------------------------------------------
 ! initializing iterations counter and iterative solution flag.
 ! ----------------------------------------------------------------------
+
     if (parameters%bexp(isoil) >  blim) bx = blim
+    nlog = 0
+
 ! ----------------------------------------------------------------------
 !  if temperature not significantly below freezing (tfrz), sh2o = smc
 ! ----------------------------------------------------------------------
@@ -6923,58 +6926,57 @@ zolmax = xkrefsqr / sqrt(xkzo)   ! maximum z/L
     if (tkelv > (tfrz- 1.e-3)) then
        free = smc
     else
+
 ! ----------------------------------------------------------------------
 ! option 1: iterated solution in koren et al, jgr, 1999, eqn 17
 ! ----------------------------------------------------------------------
 ! initial guess for swl (frozen content)
 ! ----------------------------------------------------------------------
-      if (ck /= 0.0) then
-        swl = smc - sh2o
+       if (ck /= 0.0) then
+          swl = smc - sh2o
 ! ----------------------------------------------------------------------
 ! keep within bounds.
 ! ----------------------------------------------------------------------
-        if (swl > (smc -0.02)) swl = smc -0.02
+          if (swl > (smc -0.02)) swl = smc -0.02
 ! ----------------------------------------------------------------------
 !  start of iterations
 ! ----------------------------------------------------------------------
-        if (swl < 0.) swl = 0.
+          if (swl < 0.) swl = 0.
           
-! ----------------------------------------------------------------------
-! if more than 10 iterations, use explicit method (ck=0 approx.)
-! when dswl less or eq. error, no more iterations required.
-! ----------------------------------------------------------------------
-        do nlog = 0,9          
-          df = log ( ( parameters%psisat(isoil) * grav / hfus ) * ( ( 1. + ck * swl )**2.) * &
-               ( parameters%smcmax(isoil) / (smc - swl) )** bx) - log ( - (               &
-               tkelv - tfrz)/ tkelv)
-          denom = 2. * ck / ( 1. + ck * swl ) + bx / ( smc - swl )
-          swlk = swl - df / denom
+          ! Use do while loop instead of goto statements
+          do while ((nlog < 10) .and. (kcount == 0))
+             nlog = nlog + 1
+             df = log ( ( parameters%psisat(isoil) * grav / hfus ) * ( ( 1. + ck * swl )**2.) * &
+                  ( parameters%smcmax(isoil) / (smc - swl) )** bx) - log ( - (               &
+                  tkelv - tfrz)/ tkelv)
+             denom = 2. * ck / ( 1. + ck * swl ) + bx / ( smc - swl )
+             swlk = swl - df / denom
 ! ----------------------------------------------------------------------
 ! bounds useful for mathematical solution.
 ! ----------------------------------------------------------------------
-          if (swlk > (smc -0.02)) swlk = smc - 0.02
-          if (swlk < 0.) swlk = 0.
+             if (swlk > (smc -0.02)) swlk = smc - 0.02
+             if (swlk < 0.) swlk = 0.
 
 ! ----------------------------------------------------------------------
 ! mathematical solution bounds applied.
 ! ----------------------------------------------------------------------
-          dswl = abs (swlk - swl)
-! ----------------------------------------------------------------------            
-! check if dswl less or eq. error, no more iterations required if true
+             dswl = abs (swlk - swl)
+! if more than 10 iterations, use explicit method (ck=0 approx.)
+! when dswl less or eq. error, no more iterations required.
 ! ----------------------------------------------------------------------
-          swl = swlk
-          if ( dswl <= error ) then
-            kcount = kcount+1
-            exit
-          end if
-        end do
+             swl = swlk
+             if ( dswl <= error ) then
+                kcount = kcount + 1
+             end if
 ! ----------------------------------------------------------------------
 !  end of iterations
 ! ----------------------------------------------------------------------
 ! bounds applied within do-block are valid for physical solution.
 ! ----------------------------------------------------------------------
-        free = smc - swl
-      end if
+          end do
+          
+          free = smc - swl
+       end if
 ! ----------------------------------------------------------------------
 ! end option 1
 ! ----------------------------------------------------------------------

--- a/src/module_sf_noahmplsm.F90
+++ b/src/module_sf_noahmplsm.F90
@@ -3003,42 +3003,41 @@ endif   ! croptype == 0
     if (ib.eq.1) fsun = 0.
   end do
 
-  if(cosz <= 0) goto 100
+  if(cosz > 0)
+  ! weight reflectance/transmittance by lai and sai
 
-! weight reflectance/transmittance by lai and sai
+    do ib = 1, nband
+      vai = elai + esai
+      wl  = elai / max(vai,mpe)
+      ws  = esai / max(vai,mpe)
+      rho(ib) = max(parameters%rhol(ib)*wl+parameters%rhos(ib)*ws, mpe)
+      tau(ib) = max(parameters%taul(ib)*wl+parameters%taus(ib)*ws, mpe)
+    end do
 
-  do ib = 1, nband
-    vai = elai + esai
-    wl  = elai / max(vai,mpe)
-    ws  = esai / max(vai,mpe)
-    rho(ib) = max(parameters%rhol(ib)*wl+parameters%rhos(ib)*ws, mpe)
-    tau(ib) = max(parameters%taul(ib)*wl+parameters%taus(ib)*ws, mpe)
-  end do
+  ! snow age
 
-! snow age
+    call snow_age (parameters,dt,tg,sneqvo,sneqv,tauss,fage)
 
-   call snow_age (parameters,dt,tg,sneqvo,sneqv,tauss,fage)
+  ! snow albedos: only if cosz > 0 and fsno > 0
 
-! snow albedos: only if cosz > 0 and fsno > 0
+    if(opt_alb == 1) &
+      call snowalb_bats (parameters,nband, fsno,cosz,fage,albsnd,albsni)
+    if(opt_alb == 2) then
+      call snowalb_class (parameters,nband,qsnow,dt,alb,albold,albsnd,albsni,iloc,jloc)
+      albold = alb
+    end if
 
-  if(opt_alb == 1) &
-     call snowalb_bats (parameters,nband, fsno,cosz,fage,albsnd,albsni)
-  if(opt_alb == 2) then
-     call snowalb_class (parameters,nband,qsnow,dt,alb,albold,albsnd,albsni,iloc,jloc)
-     albold = alb
-  end if
+  ! ground surface albedo
 
-! ground surface albedo
+    call groundalb (parameters,nsoil   ,nband   ,ice     ,ist     , & !in
+                    fsno    ,smc     ,albsnd  ,albsni  ,cosz    , & !in
+                    tg      ,iloc    ,jloc    ,                   & !in
+                    albgrd  ,albgri  )                              !out
 
-  call groundalb (parameters,nsoil   ,nband   ,ice     ,ist     , & !in
-                  fsno    ,smc     ,albsnd  ,albsni  ,cosz    , & !in
-                  tg      ,iloc    ,jloc    ,                   & !in
-                  albgrd  ,albgri  )                              !out
+  ! loop over nband wavebands to calculate surface albedos and solar
+  ! fluxes for unit incoming direct (ic=0) and diffuse flux (ic=1)
 
-! loop over nband wavebands to calculate surface albedos and solar
-! fluxes for unit incoming direct (ic=0) and diffuse flux (ic=1)
-
-  do ib = 1, nband
+    do ib = 1, nband
       ic = 0      ! direct
       call twostream (parameters,ib     ,ic      ,vegtyp  ,cosz    ,vai    , & !in
                       fwet   ,tv      ,albgrd  ,albgri  ,rho    , & !in
@@ -3053,22 +3052,21 @@ endif   ! croptype == 0
                       fabi   ,albi    ,ftdi    ,ftii    ,gdir   , & !)   !out
                       frevi  ,fregi   ,bgap    ,wgap)
 
-  end do
+    end do
 
-! sunlit fraction of canopy. set fsun = 0 if fsun < 0.01.
+  ! sunlit fraction of canopy. set fsun = 0 if fsun < 0.01.
 
-  ext = gdir/cosz * sqrt(1.-rho(1)-tau(1))
-  fsun = (1.-exp(-ext*vai)) / max(ext*vai,mpe)
-  ext = fsun
+    ext = gdir/cosz * sqrt(1.-rho(1)-tau(1))
+    fsun = (1.-exp(-ext*vai)) / max(ext*vai,mpe)
+    ext = fsun
 
-  if (ext .lt. 0.01) then
-     wl = 0.
-  else
-     wl = ext 
+    if (ext .lt. 0.01) then
+      wl = 0.
+    else
+      wl = ext 
+    end if
+    fsun = wl
   end if
-  fsun = wl
-
-100 continue
 
   end subroutine albedo
 
@@ -6902,7 +6900,7 @@ zolmax = xkrefsqr / sqrt(xkzo)   ! maximum z/L
     integer, intent(inout)           :: errflg
 #endif
     real (kind=kind_phys)                 :: bx,denom,df,dswl,fk,swl,swlk
-    integer              :: nlog,kcount
+    integer              :: nlog
 !      parameter(ck = 0.0)
     real (kind=kind_phys), parameter      :: ck = 8.0, blim = 5.5, error = 0.005,       &
          dice = 920.0
@@ -6917,10 +6915,7 @@ zolmax = xkrefsqr / sqrt(xkzo)   ! maximum z/L
 ! ----------------------------------------------------------------------
 ! initializing iterations counter and iterative solution flag.
 ! ----------------------------------------------------------------------
-
     if (parameters%bexp(isoil) >  blim) bx = blim
-    nlog = 0
-
 ! ----------------------------------------------------------------------
 !  if temperature not significantly below freezing (tfrz), sh2o = smc
 ! ----------------------------------------------------------------------
@@ -6928,25 +6923,27 @@ zolmax = xkrefsqr / sqrt(xkzo)   ! maximum z/L
     if (tkelv > (tfrz- 1.e-3)) then
        free = smc
     else
-
 ! ----------------------------------------------------------------------
 ! option 1: iterated solution in koren et al, jgr, 1999, eqn 17
 ! ----------------------------------------------------------------------
 ! initial guess for swl (frozen content)
 ! ----------------------------------------------------------------------
-       if (ck /= 0.0) then
-          swl = smc - sh2o
+      if (ck /= 0.0) then
+        swl = smc - sh2o
 ! ----------------------------------------------------------------------
 ! keep within bounds.
 ! ----------------------------------------------------------------------
-          if (swl > (smc -0.02)) swl = smc -0.02
+        if (swl > (smc -0.02)) swl = smc -0.02
 ! ----------------------------------------------------------------------
 !  start of iterations
 ! ----------------------------------------------------------------------
-          if (swl < 0.) swl = 0.
-1001      continue
-          if (.not.( (nlog < 10) .and. (kcount == 0)))   goto 1002
-          nlog = nlog +1
+        if (swl < 0.) swl = 0.
+          
+! ----------------------------------------------------------------------
+! if more than 10 iterations, use explicit method (ck=0 approx.)
+! when dswl less or eq. error, no more iterations required.
+! ----------------------------------------------------------------------
+        do nlog = 0,9          
           df = log ( ( parameters%psisat(isoil) * grav / hfus ) * ( ( 1. + ck * swl )**2.) * &
                ( parameters%smcmax(isoil) / (smc - swl) )** bx) - log ( - (               &
                tkelv - tfrz)/ tkelv)
@@ -6962,22 +6959,22 @@ zolmax = xkrefsqr / sqrt(xkzo)   ! maximum z/L
 ! mathematical solution bounds applied.
 ! ----------------------------------------------------------------------
           dswl = abs (swlk - swl)
-! if more than 10 iterations, use explicit method (ck=0 approx.)
-! when dswl less or eq. error, no more iterations required.
+! ----------------------------------------------------------------------            
+! check if dswl less or eq. error, no more iterations required if true
 ! ----------------------------------------------------------------------
           swl = swlk
           if ( dswl <= error ) then
-             kcount = kcount +1
+            kcount = kcount+1
+            exit
           end if
+        end do
 ! ----------------------------------------------------------------------
 !  end of iterations
 ! ----------------------------------------------------------------------
 ! bounds applied within do-block are valid for physical solution.
 ! ----------------------------------------------------------------------
-          goto 1001
-1002      continue
-          free = smc - swl
-       end if
+        free = smc - swl
+      end if
 ! ----------------------------------------------------------------------
 ! end option 1
 ! ----------------------------------------------------------------------


### PR DESCRIPTION
There is a requirement from NCO to remove deprecated `goto` statements in the GFS package (including submodules). There were only 3 `goto` statements in the noahmp code and this PR removes those statements and reworks the code to keep the same logic.

Also a write statement was removed. This statement was being triggered if land IAU was active. This created a large amount of unnecessary lines to be written to stdout. (ex. GDAS case went from ~20k lines to ~2 million). Since the line does not seem to be a warning or error, we decided to remove it instead of writing it when on the master PE. 

This code was tested against the regression test suite in the UFS and produced no changes to baselines as expected, but it should be noted that not all of the RTs use the LSM.  