### PR TITLE
Noahmp No STCSLC Adjustment for 0 increments

### DIFF
--- a/drivers/ccpp/lnd_iau_mod.F90
+++ b/drivers/ccpp/lnd_iau_mod.F90
@@ -81,7 +81,8 @@ module land_iau_mod
       logical              :: upd_slc
       logical              :: do_stcsmc_adjustment  !do moisture/temperature adjustment for consistency after increment add
       real(kind=kind_phys) :: min_T_increment
- 
+      real(kind=kind_phys) :: min_SLC_increment
+
       integer              :: me              !< MPI rank designator
       integer              :: mpi_root        !< MPI rank of master atmosphere processor
       character(len=64)    :: fn_nml          !< namelist filename for surface data cycling
@@ -97,13 +98,13 @@ module land_iau_mod
 
 contains
 
-subroutine land_iau_mod_set_control(Land_IAU_Control,fn_nml,input_nml_file_i, me, mpi_root, &
+subroutine land_iau_mod_set_control(Land_IAU_Control,fn_nml,input_nml_file, me, mpi_root, &
                                    isc, jsc, nx, ny, tile_num, nblks, blksz, &
                                    lsoil, lsnow_lsm, dtp, fhour, errmsg, errflg)          
 
    type (land_iau_control_type), intent(inout) :: Land_IAU_Control
    character(*), intent(in)                    :: fn_nml               !< namelist filename for surface data cycling
-   character(len=:), intent(in), dimension(:), pointer :: input_nml_file_i
+   character(len=:), intent(in), dimension(:), pointer :: input_nml_file
    integer, intent(in)                        :: me, mpi_root          !< MPI rank of master atmosphere processor   
    integer, intent(in)                        :: isc, jsc, nx, ny, tile_num, nblks, lsoil, lsnow_lsm
    integer, dimension(:),          intent(in) :: blksz                 !(one:) !GFS_Control%blksz
@@ -118,7 +119,6 @@ subroutine land_iau_mod_set_control(Land_IAU_Control,fn_nml,input_nml_file_i, me
    logical                                    :: exists
    character(len=512)                         :: ioerrmsg
 
-   character(len=:), pointer, dimension(:)    :: input_nml_file => null()
    character(len=4)                           :: iosstr
 
    !> land iau setting read from namelist
@@ -133,21 +133,17 @@ subroutine land_iau_mod_set_control(Land_IAU_Control,fn_nml,input_nml_file_i, me
    logical               :: land_iau_upd_slc = .false.
    logical               :: land_iau_do_stcsmc_adjustment = .false.
    real(kind=kind_phys)  :: land_iau_min_T_increment = 0.0001
-  
+   real(kind=kind_phys)  :: land_iau_min_SLC_increment = 0.000001
+
    NAMELIST /land_iau_nml/ do_land_iau, land_iau_delthrs, land_iau_inc_files, land_iau_fhrs,   &  
-                        land_iau_filter_increments, &  
-                        lsoil_incr, land_iau_upd_stc, land_iau_upd_slc, land_iau_do_stcsmc_adjustment, land_iau_min_T_increment                                    
-   
+                        land_iau_filter_increments, lsoil_incr, land_iau_upd_stc, land_iau_upd_slc, &
+                        land_iau_do_stcsmc_adjustment, land_iau_min_T_increment, land_iau_min_SLC_increment                               
    !Errors messages handled through CCPP error handling variables
    errmsg = ''
    errflg = 0
 
 !3.11.24: copied from GFS_typedefs.F90 
 #ifdef INTERNAL_FILE_NML
-    ! allocate required to work around GNU compiler bug 100886
-    ! https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100886
-    allocate(input_nml_file, mold=input_nml_file_i)
-    input_nml_file => input_nml_file_i
     read(input_nml_file, nml=land_iau_nml, ERR=888, END=999, iostat=ios)
 #else
    inquire (file=trim(fn_nml), exist=exists)    ! TODO: this maybe be replaced by nlunit passed from ccpp
@@ -214,6 +210,7 @@ subroutine land_iau_mod_set_control(Land_IAU_Control,fn_nml,input_nml_file_i, me
    Land_IAU_Control%upd_slc = land_iau_upd_slc
    Land_IAU_Control%do_stcsmc_adjustment = land_iau_do_stcsmc_adjustment
    Land_IAU_Control%min_T_increment = land_iau_min_T_increment
+   Land_IAU_Control%min_SLC_increment = land_iau_min_SLC_increment
 
    allocate(Land_IAU_Control%blksz(nblks))
    allocate(Land_IAU_Control%blk_strt_indx(nblks))
@@ -627,6 +624,7 @@ subroutine read_iau_forcing_fv3(Land_IAU_Control, wk3_stc, wk3_slc, errmsg, errf
    
    !set too small increments to zero
    where(abs(wk3_stc) < Land_IAU_Control%min_T_increment) wk3_stc = 0.0
+   where(abs(wk3_slc) < Land_IAU_Control%min_SLC_increment) wk3_slc = 0.0
 
    status =nf90_close(ncid) 
    call netcdf_err(status, 'closing file '//trim(fname), errflg, errmsg) 

--- a/drivers/ccpp/noahmpdrv.F90
+++ b/drivers/ccpp/noahmpdrv.F90
@@ -325,19 +325,21 @@ subroutine noahmpdrv_timestep_init (itime, fhour, delt, km,  ncols,         &
             n_stc = n_stc+1
             soiltype = soiltyp(i)
             do l = 1, lsoil_incr
+              if (abs(stc_inc_flat(i,l)) > Land_IAU_Control%min_T_increment)
+                !the following if case applies when updated stc > melting point, it handles both
                 !case 1: frz ==> frz, recalculate slc, smc remains
                 !case 2: unfrz ==> frz, recalculate slc, smc remains
-                !both cases are considered in the following if case
                 if (stc(i,l) .LT. con_t0c )then
                   !recompute supercool liquid water,smc_anl remain unchanged
                   smp = con_hfus*(con_t0c-stc(i,l))/(con_g*stc(i,l)) !(m)
                   slc_new=maxsmc(soiltype)*(smp/satpsi(soiltype))**(-1./bb(soiltype))
                   slc(i,l) = max( min( slc_new, smc(i,l)), 0.0 )
                 endif
-                !case 3: frz ==> unfrz, melt all soil ice (if any)
+                !case 3: frz ==> unfrz (or unfrz ==> unfrz), melt all soil ice (if any)
                 if (stc(i,l) .GT. con_t0c )then !do not rely on stc_bck
                   slc(i,l)=smc(i,l)
                 endif
+              endif
             enddo
         endif
       enddo    
@@ -353,10 +355,12 @@ subroutine noahmpdrv_timestep_init (itime, fhour, delt, km,  ncols,         &
           n_slc = n_slc+1
           ! apply SM bounds (later: add upper SMC limit)
           do l = 1, lsoil_incr
-            ! noah-mp minimum is 1 mm per layer (in SMC)
-            ! no need to maintain frozen amount, would be v. small.
-            slc(i,l) = max( 0.001/dz(l), slc(i,l) )
-            smc(i,l) = max( 0.001/dz(l), smc(i,l) )
+            if (abs(slc_inc_flat(i, l)) > Land_IAU_Control%min_SLC_increment) then
+              ! noah-mp minimum is 1 mm per layer (in SMC)
+              ! no need to maintain frozen amount, would be v. small.
+              slc(i,l) = max( 0.001/dz(l), slc(i,l) )
+              smc(i,l) = max( 0.001/dz(l), smc(i,l) )
+            endif
           enddo
         endif
       enddo
@@ -365,9 +369,11 @@ subroutine noahmpdrv_timestep_init (itime, fhour, delt, km,  ncols,         &
 
     deallocate(stc_updated, slc_updated)
     deallocate(mask_tile)
-  
-    write(*,'(a,i4,a,i8)') 'noahmpdrv_timestep_init rank ', Land_IAU_Control%me, ' # of cells with stc update ', nstcupd
-
+ 
+    if(Land_IAU_Control%me == Land_IAU_Control%mpi_root .or. print_update_stats) then 
+      write(*,'(a,i4,a,i8)') 'noahmpdrv_timestep_init rank ', Land_IAU_Control%me, ' # of cells with stc update ', nstcupd
+      write(*,'(a,i4,a,i8)') 'noahmpdrv_timestep_init rank ', Land_IAU_Control%me, ' # of cells with slc update ', nslcupd
+    endif
 
 end subroutine noahmpdrv_timestep_init
 

--- a/drivers/ccpp/noahmpdrv.F90
+++ b/drivers/ccpp/noahmpdrv.F90
@@ -308,8 +308,6 @@ subroutine noahmpdrv_timestep_init (itime, fhour, delt, km,  ncols,         &
     endif ! if soil/snow point
   enddo ij_loop
 
-  deallocate(stc_inc_flat, slc_inc_flat) 
-
  !!do moisture/temperature adjustment for consistency after increment add 
   call read_mp_table_parameters(errmsg, errflg)          
   if (errflg .ne. 0) then
@@ -367,7 +365,7 @@ subroutine noahmpdrv_timestep_init (itime, fhour, delt, km,  ncols,         &
     endif
   endif
 
-    deallocate(stc_updated, slc_updated)
+    deallocate(stc_inc_flat, slc_inc_flat, stc_updated, slc_updated)
     deallocate(mask_tile)
     ! Remove non-warning/error log write
     !write(*,'(a,i4,a,i8)') 'noahmpdrv_timestep_init rank ', Land_IAU_Control%me, ' # of cells with stc update ', nstcupd

--- a/drivers/ccpp/noahmpdrv.F90
+++ b/drivers/ccpp/noahmpdrv.F90
@@ -325,7 +325,7 @@ subroutine noahmpdrv_timestep_init (itime, fhour, delt, km,  ncols,         &
             n_stc = n_stc+1
             soiltype = soiltyp(i)
             do l = 1, lsoil_incr
-              if (abs(stc_inc_flat(i,l)) > Land_IAU_Control%min_T_increment)
+              if (abs(stc_inc_flat(i,l)) > Land_IAU_Control%min_T_increment) then
                 !the following if case applies when updated stc > melting point, it handles both
                 !case 1: frz ==> frz, recalculate slc, smc remains
                 !case 2: unfrz ==> frz, recalculate slc, smc remains


### PR DESCRIPTION
After adding soil moisture (SLC) and temperature (STC) increments in Noahmp driver, adjustments are made to ensure consistency between liquid/frozen soil moisture and temperature. Currently this is applied even when all the increments are (intentionally) 0. We do not want to change the physics model predicted states when no/zero increments are added to STC and SLC

The changes introduced in this PR check and skip the adjustment section if the magnitude of an increment is zero (below threshold).

Tested by running a low-res (C384C192) global workflow case with Soil DA, and comparing it to previous outputs without the code changes here. The results outputs have the expected changes.

Related to 
https://github.com/ufs-community/ccpp-physics/issues/323
https://github.com/NOAA-EMC/ufsatm/issues/1024
https://github.com/ufs-community/ufs-weather-model/issues/2934